### PR TITLE
feat: Milestone 2 - Providers

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -1,0 +1,274 @@
+//! Anthropic Claude provider with real SSE streaming.
+
+#![allow(dead_code)]
+use super::{ChatMessage, ChatProvider, StreamChunk};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+pub struct AnthropicProvider {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicProvider {
+    pub fn new(api_key: String, model: &str) -> Self {
+        Self {
+            api_key,
+            model: model.to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct AnthropicMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicContent {
+    text: String,
+}
+
+/// SSE event types from Anthropic streaming API
+#[derive(Deserialize)]
+struct AnthropicStreamEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    delta: Option<AnthropicDelta>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicDelta {
+    #[serde(rename = "type")]
+    delta_type: Option<String>,
+    text: Option<String>,
+}
+
+fn split_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<AnthropicMessage>) {
+    let system = messages.iter().find(|m| m.role == "system").map(|m| m.content.clone());
+    let msgs = messages
+        .iter()
+        .filter(|m| m.role != "system")
+        .map(|m| AnthropicMessage { role: m.role.clone(), content: m.content.clone() })
+        .collect();
+    (system, msgs)
+}
+
+#[async_trait]
+impl ChatProvider for AnthropicProvider {
+    fn name(&self) -> &str { "anthropic" }
+    fn model(&self) -> &str { &self.model }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String> {
+        let (system, msgs) = split_messages(messages);
+        let request = AnthropicRequest {
+            model: self.model.clone(),
+            max_tokens: 4096,
+            messages: msgs,
+            system,
+            stream: None,
+        };
+
+        let response = self.client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Anthropic API error ({}): {}", status, body);
+        }
+
+        let parsed: AnthropicResponse = response.json().await?;
+        Ok(parsed.content.first().map(|c| c.text.clone()).unwrap_or_default())
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String> {
+        let (system, msgs) = split_messages(messages);
+        let request = AnthropicRequest {
+            model: self.model.clone(),
+            max_tokens: 4096,
+            messages: msgs,
+            system,
+            stream: Some(true),
+        };
+
+        let response = self.client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Anthropic streaming API error ({}): {}", status, body);
+        }
+
+        let mut full_text = String::new();
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk?;
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+            // SSE events separated by "\n\n"
+            while let Some(pos) = buffer.find("\n\n") {
+                let event = buffer[..pos].to_string();
+                buffer = buffer[pos + 2..].to_string();
+
+                let mut event_type_line = String::new();
+                let mut data_line = String::new();
+
+                for line in event.lines() {
+                    if let Some(t) = line.strip_prefix("event: ") {
+                        event_type_line = t.to_string();
+                    } else if let Some(d) = line.strip_prefix("data: ") {
+                        data_line = d.to_string();
+                    }
+                }
+
+                // We care about content_block_delta events
+                if event_type_line == "content_block_delta" || !event_type_line.is_empty() {
+                    if let Ok(parsed) = serde_json::from_str::<AnthropicStreamEvent>(&data_line) {
+                        if parsed.event_type == "content_block_delta" {
+                            if let Some(delta) = &parsed.delta {
+                                if delta.delta_type.as_deref() == Some("text_delta") {
+                                    if let Some(text) = &delta.text {
+                                        full_text.push_str(text);
+                                        on_chunk(StreamChunk { content: text.clone(), done: false });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        on_chunk(StreamChunk { content: String::new(), done: true });
+        Ok(full_text)
+    }
+
+    async fn is_available(&self) -> bool {
+        !self.api_key.is_empty()
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[crate::providers::ToolDefinition],
+    ) -> anyhow::Result<crate::providers::ToolCallResult> {
+        use serde_json::{json, Value};
+
+        let (system, msgs) = split_messages(messages);
+
+        let anthropic_tools: Vec<Value> = tools.iter().map(|t| {
+            json!({
+                "name": t.name,
+                "description": t.description,
+                "input_schema": t.parameters
+            })
+        }).collect();
+
+        let mut request = json!({
+            "model": self.model,
+            "max_tokens": 4096,
+            "messages": msgs.iter().map(|m| json!({ "role": m.role, "content": m.content })).collect::<Vec<_>>(),
+            "tools": anthropic_tools
+        });
+        if let Some(sys) = system {
+            request["system"] = json!(sys);
+        }
+
+        let response = self.client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Anthropic tool call API error ({}): {}", status, body);
+        }
+
+        let body: Value = response.json().await?;
+
+        // Anthropic returns content as an array of blocks
+        if let Some(content_arr) = body["content"].as_array() {
+            let tool_calls: Vec<crate::providers::ToolCall> = content_arr
+                .iter()
+                .filter(|block| block["type"].as_str() == Some("tool_use"))
+                .map(|block| {
+                    let id = block["id"].as_str().unwrap_or("").to_string();
+                    let name = block["name"].as_str().unwrap_or("").to_string();
+                    let arguments = block["input"]
+                        .as_object()
+                        .map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| {
+                                    (k.clone(), v.as_str().map(|s| s.to_string())
+                                        .unwrap_or_else(|| v.to_string()))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    crate::providers::ToolCall { id, name, arguments }
+                })
+                .collect();
+
+            if !tool_calls.is_empty() {
+                return Ok(crate::providers::ToolCallResult::ToolCalls(tool_calls));
+            }
+
+            // Collect text blocks
+            let text: String = content_arr
+                .iter()
+                .filter(|b| b["type"].as_str() == Some("text"))
+                .filter_map(|b| b["text"].as_str())
+                .collect::<Vec<_>>()
+                .join("");
+            return Ok(crate::providers::ToolCallResult::Text(text));
+        }
+
+        Ok(crate::providers::ToolCallResult::Text(String::new()))
+    }
+}

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1,0 +1,287 @@
+//! Google Gemini provider with real SSE streaming.
+
+use super::{ChatMessage, ChatProvider, StreamChunk};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+pub struct GeminiProvider {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl GeminiProvider {
+    pub fn new(api_key: String, model: &str) -> Self {
+        Self {
+            api_key,
+            model: model.to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct GeminiRequest {
+    contents: Vec<GeminiContent>,
+    #[serde(rename = "generationConfig", skip_serializing_if = "Option::is_none")]
+    generation_config: Option<GeminiGenerationConfig>,
+}
+
+#[derive(Serialize)]
+struct GeminiContent {
+    role: String,
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+struct GeminiPart {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct GeminiGenerationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Vec<GeminiCandidate>,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidate {
+    content: GeminiContentResponse,
+}
+
+#[derive(Deserialize)]
+struct GeminiContentResponse {
+    parts: Vec<GeminiPartResponse>,
+}
+
+#[derive(Deserialize)]
+struct GeminiPartResponse {
+    text: String,
+}
+
+fn build_contents(messages: &[ChatMessage]) -> Vec<GeminiContent> {
+    // Gemini has no "system" role — prepend system content to the first user message
+    let mut contents: Vec<GeminiContent> = Vec::new();
+    let mut system_prefix = String::new();
+
+    for m in messages {
+        if m.role == "system" {
+            system_prefix.push_str(&m.content);
+            system_prefix.push('\n');
+        }
+    }
+
+    for m in messages {
+        if m.role == "system" {
+            continue;
+        }
+        let text = if !system_prefix.is_empty() && m.role == "user" && contents.is_empty() {
+            format!("{}{}", system_prefix, m.content)
+        } else {
+            m.content.clone()
+        };
+        contents.push(GeminiContent {
+            role: if m.role == "assistant" { "model".to_string() } else { "user".to_string() },
+            parts: vec![GeminiPart { text }],
+        });
+    }
+
+    contents
+}
+
+#[async_trait]
+impl ChatProvider for GeminiProvider {
+    fn name(&self) -> &str { "gemini" }
+    fn model(&self) -> &str { &self.model }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String> {
+        let request = GeminiRequest {
+            contents: build_contents(messages),
+            generation_config: Some(GeminiGenerationConfig { max_output_tokens: Some(8192) }),
+        };
+
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+            self.model, self.api_key
+        );
+
+        let response = self.client.post(&url).json(&request).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Gemini API error ({}): {}", status, body);
+        }
+
+        let parsed: GeminiResponse = response.json().await?;
+        Ok(parsed
+            .candidates
+            .first()
+            .and_then(|c| c.content.parts.first())
+            .map(|p| p.text.clone())
+            .unwrap_or_default())
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String> {
+        let request = GeminiRequest {
+            contents: build_contents(messages),
+            generation_config: Some(GeminiGenerationConfig { max_output_tokens: Some(8192) }),
+        };
+
+        // :streamGenerateContent with alt=sse returns SSE events
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:streamGenerateContent?alt=sse&key={}",
+            self.model, self.api_key
+        );
+
+        let response = self.client.post(&url).json(&request).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Gemini streaming API error ({}): {}", status, body);
+        }
+
+        let mut full_text = String::new();
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk?;
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+            // SSE events are separated by "\n\n"
+            while let Some(pos) = buffer.find("\n\n") {
+                let event = buffer[..pos].to_string();
+                buffer = buffer[pos + 2..].to_string();
+
+                for line in event.lines() {
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        if data == "[DONE]" {
+                            continue;
+                        }
+                        if let Ok(parsed) = serde_json::from_str::<GeminiResponse>(data) {
+                            if let Some(text) = parsed
+                                .candidates
+                                .first()
+                                .and_then(|c| c.content.parts.first())
+                                .map(|p| p.text.clone())
+                            {
+                                full_text.push_str(&text);
+                                on_chunk(StreamChunk { content: text, done: false });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        on_chunk(StreamChunk { content: String::new(), done: true });
+        Ok(full_text)
+    }
+
+    async fn is_available(&self) -> bool {
+        !self.api_key.is_empty()
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[crate::providers::ToolDefinition],
+    ) -> anyhow::Result<crate::providers::ToolCallResult> {
+        use serde_json::{json, Value};
+
+        // Gemini function declarations format
+        let function_declarations: Vec<Value> = tools.iter().map(|t| {
+            json!({
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters
+            })
+        }).collect();
+
+        let contents = build_contents(messages);
+
+        let mut request_body = json!({
+            "contents": contents,
+            "generationConfig": { "maxOutputTokens": 8192 }
+        });
+
+        if !function_declarations.is_empty() {
+            request_body["tools"] = json!([{
+                "functionDeclarations": function_declarations
+            }]);
+            // Auto mode: model decides when to call functions
+            request_body["toolConfig"] = json!({
+                "functionCallingConfig": { "mode": "AUTO" }
+            });
+        }
+
+        let url = format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+            self.model, self.api_key
+        );
+
+        let response = self.client.post(&url).json(&request_body).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Gemini tool call API error ({}): {}", status, body);
+        }
+
+        let body: Value = response.json().await?;
+        let candidate = &body["candidates"][0]["content"];
+        let parts = candidate["parts"].as_array();
+
+        // Check for function calls in the response parts
+        if let Some(parts) = parts {
+            let mut tool_calls = Vec::new();
+            let mut text_parts = Vec::new();
+
+            for part in parts {
+                if let Some(fc) = part.get("functionCall") {
+                    let name = fc["name"].as_str().unwrap_or("").to_string();
+                    let args = fc.get("args").cloned().unwrap_or(Value::Object(Default::default()));
+                    let arguments: std::collections::HashMap<String, String> = args
+                        .as_object()
+                        .map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| (k.clone(), v.as_str()
+                                    .map(|s| s.to_string())
+                                    .unwrap_or_else(|| v.to_string())))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    tool_calls.push(crate::providers::ToolCall {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name,
+                        arguments,
+                    });
+                } else if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    text_parts.push(text.to_string());
+                }
+            }
+
+            if !tool_calls.is_empty() {
+                return Ok(crate::providers::ToolCallResult::ToolCalls(tool_calls));
+            }
+            if !text_parts.is_empty() {
+                return Ok(crate::providers::ToolCallResult::Text(text_parts.join("")));
+            }
+        }
+
+        Ok(crate::providers::ToolCallResult::Text(String::new()))
+    }
+}

--- a/src/providers/groq.rs
+++ b/src/providers/groq.rs
@@ -1,0 +1,436 @@
+//! Groq provider — OpenAI-compatible API with Compound (server-side tool) support.
+//!
+//! Standard models (llama-4-scout, qwen3-32b, etc.): same as OpenAI — chat, streaming, tool calling.
+//! Compound models (groq/compound, groq/compound-mini): tools executed server-side by Groq.
+
+#![allow(dead_code)]
+use super::{ChatMessage, ChatProvider, StreamChunk, ToolCall, ToolCallResult, ToolDefinition};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_BASE_URL: &str = "https://api.groq.com/openai/v1";
+
+pub struct GroqProvider {
+    api_key: String,
+    model: String,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl GroqProvider {
+    pub fn new(api_key: String, model: &str, base_url: Option<String>) -> Self {
+        Self {
+            api_key,
+            model: model.to_string(),
+            base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Returns true if the current model is a Compound model (server-side tools).
+    fn is_compound(&self) -> bool {
+        self.model.starts_with("groq/compound")
+    }
+}
+
+// ── Request/Response types (OpenAI-compatible) ──────────────────────────────
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<RequestMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compound_custom: Option<CompoundCustom>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RequestMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct CompoundCustom {
+    tools: CompoundTools,
+}
+
+#[derive(Serialize)]
+struct CompoundTools {
+    enabled_tools: Vec<String>,
+}
+
+impl Default for CompoundCustom {
+    fn default() -> Self {
+        Self {
+            tools: CompoundTools {
+                enabled_tools: vec![
+                    "web_search".to_string(),
+                    "code_interpreter".to_string(),
+                    "visit_website".to_string(),
+                ],
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ResponseToolCall>>,
+    #[serde(default)]
+    executed_tools: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct ResponseToolCall {
+    id: String,
+    function: FunctionCall,
+}
+
+#[derive(Deserialize)]
+struct FunctionCall {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Deserialize)]
+struct StreamResponse {
+    choices: Vec<StreamChoice>,
+}
+
+#[derive(Deserialize)]
+struct StreamChoice {
+    delta: StreamDelta,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StreamDelta {
+    content: Option<String>,
+}
+
+// ── ChatProvider implementation ─────────────────────────────────────────────
+
+#[async_trait]
+impl ChatProvider for GroqProvider {
+    fn name(&self) -> &str {
+        "groq"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String> {
+        let request_messages: Vec<RequestMessage> = messages
+            .iter()
+            .map(|m| RequestMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect();
+
+        let request = ChatRequest {
+            model: self.model.clone(),
+            messages: request_messages,
+            max_tokens: Some(4096),
+            stream: false,
+            compound_custom: if self.is_compound() {
+                Some(CompoundCustom::default())
+            } else {
+                None
+            },
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Groq API error ({}): {}", status, error_text);
+        }
+
+        let chat_response: ChatResponse = response.json().await?;
+
+        // Log executed_tools if present (compound mode transparency)
+        if let Some(choice) = chat_response.choices.first() {
+            if let Some(ref tools) = choice.message.executed_tools {
+                tracing::debug!("Groq compound executed_tools: {}", tools);
+            }
+        }
+
+        let text = chat_response
+            .choices
+            .first()
+            .and_then(|c| c.message.content.clone())
+            .unwrap_or_default();
+
+        Ok(text)
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String> {
+        let request_messages: Vec<RequestMessage> = messages
+            .iter()
+            .map(|m| RequestMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect();
+
+        let request = ChatRequest {
+            model: self.model.clone(),
+            messages: request_messages,
+            max_tokens: Some(4096),
+            stream: true,
+            compound_custom: if self.is_compound() {
+                Some(CompoundCustom::default())
+            } else {
+                None
+            },
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("Groq API error ({}): {}", status, error_text);
+        }
+
+        let mut full_response = String::new();
+        let mut stream = response.bytes_stream();
+
+        use futures::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            let text = String::from_utf8_lossy(&chunk);
+
+            for line in text.lines() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        on_chunk(StreamChunk {
+                            content: String::new(),
+                            done: true,
+                        });
+                        break;
+                    }
+
+                    if let Ok(parsed) = serde_json::from_str::<StreamResponse>(data) {
+                        if let Some(choice) = parsed.choices.first() {
+                            if let Some(content) = &choice.delta.content {
+                                full_response.push_str(content);
+                                on_chunk(StreamChunk {
+                                    content: content.clone(),
+                                    done: choice.finish_reason.is_some(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(full_response)
+    }
+
+    async fn is_available(&self) -> bool {
+        !self.api_key.is_empty()
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[ToolDefinition],
+    ) -> Result<ToolCallResult> {
+        // Compound models handle tools server-side — ignore Mithril's tools,
+        // just do a plain chat and return the final text.
+        if self.is_compound() {
+            let text = self.chat(messages).await?;
+            return Ok(ToolCallResult::Text(text));
+        }
+
+        // Standard models: OpenAI-compatible tool calling
+        use serde_json::{json, Value};
+
+        let openai_messages: Vec<Value> = messages
+            .iter()
+            .map(|m| json!({ "role": m.role, "content": m.content }))
+            .collect();
+
+        let openai_tools: Vec<Value> = tools
+            .iter()
+            .map(|t| {
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters
+                    }
+                })
+            })
+            .collect();
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let request = json!({
+            "model": self.model,
+            "messages": openai_messages,
+            "tools": openai_tools,
+            "tool_choice": "auto"
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Groq tool call API error ({}): {}", status, body);
+        }
+
+        let body: Value = response.json().await?;
+        let choice = &body["choices"][0]["message"];
+
+        // Check for tool_calls
+        if let Some(tool_calls) = choice["tool_calls"].as_array() {
+            let calls: Vec<ToolCall> = tool_calls
+                .iter()
+                .filter_map(|tc| {
+                    let id = tc["id"].as_str()?.to_string();
+                    let name = tc["function"]["name"].as_str()?.to_string();
+                    let args_str = tc["function"]["arguments"].as_str().unwrap_or("{}");
+                    let args_value: Value = serde_json::from_str(args_str).unwrap_or_default();
+                    let arguments = args_value
+                        .as_object()
+                        .map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| {
+                                    (
+                                        k.clone(),
+                                        v.as_str()
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_else(|| v.to_string()),
+                                    )
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    Some(ToolCall { id, name, arguments })
+                })
+                .collect();
+
+            if !calls.is_empty() {
+                return Ok(ToolCallResult::ToolCalls(calls));
+            }
+        }
+
+        // Plain text response
+        let text = choice["content"].as_str().unwrap_or("").to_string();
+        Ok(ToolCallResult::Text(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_compound_true() {
+        let provider = GroqProvider::new("key".into(), "groq/compound", None);
+        assert!(provider.is_compound());
+    }
+
+    #[test]
+    fn test_is_compound_mini_true() {
+        let provider = GroqProvider::new("key".into(), "groq/compound-mini", None);
+        assert!(provider.is_compound());
+    }
+
+    #[test]
+    fn test_is_compound_false_standard_model() {
+        let provider = GroqProvider::new("key".into(), "meta-llama/llama-4-scout-17b-16e-instruct", None);
+        assert!(!provider.is_compound());
+    }
+
+    #[test]
+    fn test_is_compound_false_other_model() {
+        let provider = GroqProvider::new("key".into(), "llama-3.3-70b-versatile", None);
+        assert!(!provider.is_compound());
+    }
+
+    #[test]
+    fn test_default_base_url() {
+        let provider = GroqProvider::new("key".into(), "model", None);
+        assert_eq!(provider.base_url, "https://api.groq.com/openai/v1");
+    }
+
+    #[test]
+    fn test_custom_base_url() {
+        let provider = GroqProvider::new("key".into(), "model", Some("http://proxy:8080".into()));
+        assert_eq!(provider.base_url, "http://proxy:8080");
+    }
+
+    #[test]
+    fn test_provider_name() {
+        let provider = GroqProvider::new("key".into(), "model", None);
+        assert_eq!(provider.name(), "groq");
+    }
+
+    #[test]
+    fn test_provider_model() {
+        let provider = GroqProvider::new("key".into(), "llama-4-scout", None);
+        assert_eq!(provider.model(), "llama-4-scout");
+    }
+
+    #[test]
+    fn test_compound_custom_default() {
+        let custom = CompoundCustom::default();
+        assert!(custom.tools.enabled_tools.contains(&"web_search".to_string()));
+        assert!(custom.tools.enabled_tools.contains(&"code_interpreter".to_string()));
+        assert!(custom.tools.enabled_tools.contains(&"visit_website".to_string()));
+    }
+}

--- a/src/providers/local.rs
+++ b/src/providers/local.rs
@@ -1,0 +1,327 @@
+//! Local GGUF model provider — uses a global LazyModelManager singleton per model path.
+//! Having a singleton prevents loading the same model twice when LocalProvider is
+//! instantiated multiple times (e.g. on provider switch in mithril chat).
+
+#![allow(dead_code)]
+use super::{ChatMessage, ChatProvider, StreamChunk};
+use crate::engine::{self, find_model, get_stop_tokens, ChatTemplate, LazyModelManager};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+// Global registry: model_path → Weak<LazyModelManager>
+// - Weak references allow the manager to be freed when no LocalProvider holds it.
+// - If all LocalProviders for a model are dropped, the registry entry is cleaned up.
+lazy_static! {
+    static ref MODEL_REGISTRY: Mutex<HashMap<PathBuf, std::sync::Weak<LazyModelManager>>> =
+        Mutex::new(HashMap::new());
+}
+
+fn get_or_create_manager(model_path: PathBuf) -> Arc<LazyModelManager> {
+    let mut registry = MODEL_REGISTRY.lock();
+    // Evict stale entries while we hold the lock
+    registry.retain(|_, weak| weak.strong_count() > 0);
+    // Try to upgrade existing Weak, or create a new manager
+    if let Some(weak) = registry.get(&model_path) {
+        if let Some(arc) = weak.upgrade() {
+            return arc;
+        }
+    }
+    let arc = Arc::new(LazyModelManager::new(model_path.clone(), 60));
+    registry.insert(model_path, Arc::downgrade(&arc));
+    arc
+}
+
+pub struct LocalProvider {
+    model_id: String,
+    model_path: PathBuf,
+    template: ChatTemplate,
+    manager: Arc<LazyModelManager>,
+}
+
+impl LocalProvider {
+    pub fn new(model_id: &str) -> Result<Self> {
+        let model_info = find_model(model_id)
+            .with_context(|| format!("Unknown model: {}", model_id))?;
+
+        let model_path = dirs::home_dir()
+            .context("Could not find home directory")?
+            .join(".mithril")
+            .join("models")
+            .join(model_info.file_name);
+
+        if !model_path.exists() {
+            anyhow::bail!(
+                "Model {} not downloaded. Run: mithril download-model --model {}",
+                model_id, model_id
+            );
+        }
+
+        let manager = get_or_create_manager(model_path.clone());
+        Ok(Self {
+            model_id: model_id.to_string(),
+            model_path,
+            template: model_info.chat_template,
+            manager,
+        })
+    }
+
+    fn format(&self, messages: &[ChatMessage]) -> (String, Vec<String>) {
+        let engine_msgs: Vec<engine::ChatMessage> = messages
+            .iter()
+            .map(|m| engine::ChatMessage::new(&m.role, &m.content))
+            .collect();
+        let formatted = engine::format_chat(self.template, &engine_msgs);
+        let stops = get_stop_tokens(self.template);
+        (formatted, stops)
+    }
+}
+
+#[async_trait]
+impl ChatProvider for LocalProvider {
+    fn name(&self) -> &str { "local" }
+    fn model(&self) -> &str { &self.model_id }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String> {
+        let (formatted, stops) = self.format(messages);
+        self.manager.infer(&formatted, &stops, 0.7, 2048)
+    }
+
+    /// Real token-by-token streaming via std::sync::mpsc → tokio::sync::mpsc bridge.
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String> {
+        let (formatted, stops) = self.format(messages);
+
+        let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<Option<String>>(64);
+        let (tok_tx, mut tok_rx) = tokio::sync::mpsc::channel::<Option<String>>(64);
+
+        // Start inference — sends tokens into std_tx on a detached thread
+        self.manager.infer_streaming(&formatted, &stops, 0.7, 2048, std_tx);
+
+        // Bridge: std::mpsc → tokio::mpsc (runs on blocking thread pool)
+        tokio::task::spawn_blocking(move || {
+            while let Ok(msg) = std_rx.recv() {
+                let done = msg.is_none();
+                // If receiver dropped (caller cancelled), stop the bridge
+                if tok_tx.blocking_send(msg).is_err() { break; }
+                if done { break; }
+            }
+        });
+
+        let mut full_response = String::new();
+        loop {
+            match tok_rx.recv().await {
+                Some(Some(piece)) => {
+                    full_response.push_str(&piece);
+                    on_chunk(StreamChunk { content: piece, done: false });
+                }
+                Some(None) | None => {
+                    on_chunk(StreamChunk { content: String::new(), done: true });
+                    break;
+                }
+            }
+        }
+
+        Ok(full_response)
+    }
+
+    /// Tool calling for local GGUF models via prompt injection + response parsing.
+    /// Injects tool definitions into the system prompt and parses <tool_call> blocks from output.
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[crate::providers::ToolDefinition],
+    ) -> anyhow::Result<crate::providers::ToolCallResult> {
+        use crate::providers::ToolCallResult;
+
+        if tools.is_empty() {
+            let text = self.chat(messages).await?;
+            return Ok(ToolCallResult::Text(text));
+        }
+
+        // Build tool definitions as compact JSON for the system prompt
+        let tool_json: Vec<serde_json::Value> = tools.iter().map(|t| {
+            serde_json::json!({
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters
+            })
+        }).collect();
+
+        let tool_prompt = format!(
+            r#"You have access to these tools:
+{}
+
+To call a tool, respond with EXACTLY this format (you can call multiple tools):
+<tool_call>
+{{"name": "tool_name", "arguments": {{"param": "value"}}}}
+</tool_call>
+
+If you don't need any tool, just respond with plain text (no <tool_call> tags).
+IMPORTANT: Always use <tool_call> tags when you want to use a tool. Never describe the tool call in prose."#,
+            serde_json::to_string_pretty(&tool_json).unwrap_or_default()
+        );
+
+        // Inject tool instructions into messages
+        let mut augmented = messages.to_vec();
+        if let Some(first) = augmented.first_mut() {
+            if first.role == "system" {
+                first.content = format!("{}
+
+{}", first.content, tool_prompt);
+            } else {
+                augmented.insert(0, ChatMessage::system(&tool_prompt));
+            }
+        } else {
+            augmented.insert(0, ChatMessage::system(&tool_prompt));
+        }
+
+        let response = self.chat(&augmented).await?;
+
+        // Parse tool calls from response
+        let tool_calls = parse_local_tool_calls(&response);
+
+        if tool_calls.is_empty() {
+            // No tool calls found — treat as plain text
+            // Strip any accidental partial tags
+            let clean = response
+                .replace("<tool_call>", "")
+                .replace("</tool_call>", "")
+                .trim()
+                .to_string();
+            Ok(ToolCallResult::Text(clean))
+        } else {
+            Ok(ToolCallResult::ToolCalls(tool_calls))
+        }
+    }
+
+    async fn is_available(&self) -> bool {
+        self.model_path.exists()
+    }
+}
+
+/// Parse <tool_call>...</tool_call> blocks from local model output.
+fn parse_local_tool_calls(response: &str) -> Vec<crate::providers::ToolCall> {
+    let mut calls = Vec::new();
+    let mut remaining = response;
+
+    while let Some(start) = remaining.find("<tool_call>") {
+        let after_tag = &remaining[start + "<tool_call>".len()..];
+        if let Some(end) = after_tag.find("</tool_call>") {
+            let json_str = after_tag[..end].trim();
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) {
+                let name = value["name"].as_str().unwrap_or("").to_string();
+                let args = value.get("arguments")
+                    .and_then(|a| a.as_object())
+                    .map(|obj| {
+                        obj.iter()
+                            .map(|(k, v)| (k.clone(), v.as_str()
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| v.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                if !name.is_empty() {
+                    calls.push(crate::providers::ToolCall {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        name,
+                        arguments: args,
+                    });
+                }
+            }
+            remaining = &after_tag[end + "</tool_call>".len()..];
+        } else {
+            break;
+        }
+    }
+
+    calls
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_local_tool_calls_single() {
+        let response = r#"I'll read the file for you.
+<tool_call>
+{"name": "read_psi", "arguments": {"target": "src/main.rs"}}
+</tool_call>"#;
+        let calls = parse_local_tool_calls(response);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_psi");
+        assert_eq!(calls[0].arguments["target"], "src/main.rs");
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_multiple() {
+        let response = r#"Let me check both files.
+<tool_call>
+{"name": "read_psi", "arguments": {"target": "src/main.rs"}}
+</tool_call>
+And also:
+<tool_call>
+{"name": "read_psi", "arguments": {"target": "src/lib.rs"}}
+</tool_call>"#;
+        let calls = parse_local_tool_calls(response);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].arguments["target"], "src/main.rs");
+        assert_eq!(calls[1].arguments["target"], "src/lib.rs");
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_none() {
+        let response = "I don't need any tools for this. The answer is 42.";
+        let calls = parse_local_tool_calls(response);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_malformed_json() {
+        let response = r#"<tool_call>
+not valid json at all
+</tool_call>"#;
+        let calls = parse_local_tool_calls(response);
+        assert!(calls.is_empty()); // gracefully handles bad JSON
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_missing_name() {
+        let response = r#"<tool_call>
+{"arguments": {"target": "file.rs"}}
+</tool_call>"#;
+        let calls = parse_local_tool_calls(response);
+        assert!(calls.is_empty()); // no name = skip
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_unclosed_tag() {
+        let response = r#"<tool_call>
+{"name": "read_psi", "arguments": {"target": "file.rs"}}
+"#; // no closing tag
+        let calls = parse_local_tool_calls(response);
+        assert!(calls.is_empty()); // gracefully handles missing end tag
+    }
+
+    #[test]
+    fn test_parse_local_tool_calls_with_extra_whitespace() {
+        let response = r#"
+<tool_call>
+  {"name": "list_files", "arguments": {}}
+</tool_call>
+"#;
+        let calls = parse_local_tool_calls(response);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "list_files");
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,0 +1,285 @@
+//! Chat providers — unified interface for local and cloud LLMs.
+//!
+//! All providers implement [`ChatProvider`] which exposes:
+//! - `chat()` — single response
+//! - `chat_stream()` — token-by-token streaming
+//! - `chat_with_tools()` — tool calling with structured responses
+//!
+//! ```mermaid
+//! graph LR
+//!     CP[ChatProvider trait]
+//!     CP --> L[LocalProvider]
+//!     CP --> G[GeminiProvider]
+//!     CP --> O[OpenAIProvider]
+//!     CP --> A[AnthropicProvider]
+//!     CP --> Q[GroqProvider]
+//!     L --> E[LazyModelManager]
+//!     G --> API1[Gemini API]
+//!     O --> API2[OpenAI API]
+//!     A --> API3[Anthropic API]
+//!     Q --> API4[Groq API]
+//! ```
+
+#![allow(dead_code)]
+mod local;
+mod gemini;
+mod openai;
+mod anthropic;
+mod groq;
+
+pub use local::LocalProvider;
+pub use gemini::GeminiProvider;
+pub use openai::OpenAIProvider;
+pub use anthropic::AnthropicProvider;
+pub use groq::GroqProvider;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A chat message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+impl ChatMessage {
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: content.into(),
+        }
+    }
+
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: content.into(),
+        }
+    }
+
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".to_string(),
+            content: content.into(),
+        }
+    }
+}
+
+/// Streaming chunk from provider
+#[derive(Debug, Clone)]
+pub struct StreamChunk {
+    pub content: String,
+    pub done: bool,
+}
+
+/// A tool call requested by the LLM
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    /// Unique call ID (used to match result back to call)
+    pub id: String,
+    pub name: String,
+    pub arguments: std::collections::HashMap<String, String>,
+}
+
+/// Result of chat_with_tools: either a final text reply or a tool invocation request
+#[derive(Debug)]
+pub enum ToolCallResult {
+    /// LLM finished with a text response
+    Text(String),
+    /// LLM is requesting one or more tool calls
+    ToolCalls(Vec<ToolCall>),
+}
+
+/// Definition of a tool exposed to the LLM
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    /// JSON Schema object for the parameters
+    pub parameters: serde_json::Value,
+}
+
+impl ToolDefinition {
+    pub fn from_registry_tool(tool: &dyn crate::tools::registry::Tool) -> Self {
+        use serde_json::json;
+        // M3: call parameters() once, reuse the Vec for both properties and required
+        let params = tool.parameters();
+        let properties: serde_json::Value = params.iter().fold(
+            serde_json::Map::new(),
+            |mut map, p| {
+                map.insert(p.name.clone(), json!({
+                    "type": p.param_type,
+                    "description": p.description
+                }));
+                map
+            },
+        ).into();
+        let required: Vec<&str> = params.iter()
+            .filter(|p| p.required)
+            .map(|p| p.name.as_str())
+            .collect();
+        Self {
+            name: tool.name().to_string(),
+            description: tool.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": properties,
+                "required": required
+            }),
+        }
+    }
+}
+
+/// Unified interface for chat providers
+#[async_trait]
+pub trait ChatProvider: Send + Sync {
+    /// Provider name (e.g., "local", "gemini", "openai")
+    fn name(&self) -> &str;
+
+    /// Model being used
+    fn model(&self) -> &str;
+
+    /// Generate a complete response
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String>;
+
+    /// Generate response with streaming (returns chunks via callback)
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String>;
+
+    /// Generate a response with tool calling support.
+    /// Returns either a final text or a list of tool calls to execute.
+    /// Default implementation falls back to plain chat (no tool calling).
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        _tools: &[ToolDefinition],
+    ) -> Result<ToolCallResult> {
+        let text = self.chat(messages).await?;
+        Ok(ToolCallResult::Text(text))
+    }
+
+    /// Check if provider is available (has credentials, model exists, etc.)
+    async fn is_available(&self) -> bool;
+}
+
+/// Create provider from name (uses model from global config).
+pub fn create_provider(
+    name: &str,
+    config: &crate::config::MithrilConfig,
+) -> Result<Box<dyn ChatProvider>> {
+    create_provider_with_model(name, None, config)
+}
+
+/// Create provider with an optional model override.
+/// If `model_override` is Some, uses that model instead of the global config default.
+/// This is used by the fellowship orchestrator to respect per-agent model settings.
+pub fn create_provider_with_model(
+    name: &str,
+    model_override: Option<&str>,
+    config: &crate::config::MithrilConfig,
+) -> Result<Box<dyn ChatProvider>> {
+    match name {
+        "local" => {
+            let model = model_override.unwrap_or(&config.default_model);
+            Ok(Box::new(LocalProvider::new(model)?))
+        }
+        "gemini" => {
+            let api_key = config
+                .get_credential("gemini")?
+                .ok_or_else(|| anyhow::anyhow!("Gemini API key not configured. Run: mithril config set gemini <your-api-key>"))?;
+            let model = model_override.unwrap_or(&config.providers.gemini.model);
+            Ok(Box::new(GeminiProvider::new(api_key, model)))
+        }
+        "openai" => {
+            let api_key = config
+                .get_credential("openai")?
+                .ok_or_else(|| anyhow::anyhow!("OpenAI API key not configured. Run: mithril config set openai <your-api-key>"))?;
+            let model = model_override.unwrap_or(&config.providers.openai.model);
+            Ok(Box::new(OpenAIProvider::new(
+                api_key, model, config.providers.openai.base_url.clone(),
+            )))
+        }
+        "anthropic" => {
+            let api_key = config
+                .get_credential("anthropic")?
+                .ok_or_else(|| anyhow::anyhow!("Anthropic API key not configured. Run: mithril config set anthropic <your-api-key>"))?;
+            let model = model_override.unwrap_or(&config.providers.anthropic.model);
+            Ok(Box::new(AnthropicProvider::new(api_key, model)))
+        }
+        "groq" => {
+            let api_key = config
+                .get_credential("groq")?
+                .ok_or_else(|| anyhow::anyhow!("Groq API key not configured. Run: mithril config set groq <your-api-key>"))?;
+            let model = model_override.unwrap_or(&config.providers.groq.model);
+            Ok(Box::new(GroqProvider::new(
+                api_key, model, config.providers.groq.base_url.clone(),
+            )))
+        }
+        _ => anyhow::bail!("Unknown provider: {}. Available: local, gemini, openai, anthropic, groq", name),
+    }
+}
+
+/// List all available providers
+pub fn available_providers() -> Vec<&'static str> {
+    vec!["local", "gemini", "openai", "anthropic", "groq"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chat_message_user() {
+        let msg = ChatMessage::user("hello");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content, "hello");
+    }
+
+    #[test]
+    fn test_chat_message_assistant() {
+        let msg = ChatMessage::assistant("response");
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content, "response");
+    }
+
+    #[test]
+    fn test_chat_message_system() {
+        let msg = ChatMessage::system("you are helpful");
+        assert_eq!(msg.role, "system");
+    }
+
+    #[test]
+    fn test_available_providers_includes_all() {
+        let providers = available_providers();
+        assert!(providers.contains(&"local"));
+        assert!(providers.contains(&"gemini"));
+        assert!(providers.contains(&"openai"));
+        assert!(providers.contains(&"anthropic"));
+        assert!(providers.contains(&"groq"));
+        assert_eq!(providers.len(), 5);
+    }
+
+    #[test]
+    fn test_create_provider_unknown() {
+        let config = crate::config::MithrilConfig::default();
+        let result = create_provider("nonexistent", &config);
+        assert!(result.is_err());
+        let err_msg = result.err().unwrap().to_string();
+        assert!(err_msg.contains("Unknown provider"));
+    }
+
+    #[test]
+    fn test_tool_definition_from_registry() {
+        let registry = crate::tools::create_default_registry(".");
+        let tool = registry.get("read_psi").unwrap();
+        let def = ToolDefinition::from_registry_tool(tool);
+        assert_eq!(def.name, "read_psi");
+        assert!(!def.description.is_empty());
+        assert!(def.parameters["properties"]["target"].is_object());
+    }
+}

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1,0 +1,279 @@
+//! OpenAI provider (also works with compatible APIs like Azure, Groq, etc.)
+
+#![allow(dead_code)]
+use super::{ChatMessage, ChatProvider, StreamChunk};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub struct OpenAIProvider {
+    api_key: String,
+    model: String,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl OpenAIProvider {
+    pub fn new(api_key: String, model: &str, base_url: Option<String>) -> Self {
+        Self {
+            api_key,
+            model: model.to_string(),
+            base_url: base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAIRequest {
+    model: String,
+    messages: Vec<OpenAIMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    stream: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAIMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAIResponse {
+    choices: Vec<OpenAIChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIChoice {
+    message: OpenAIMessage,
+}
+
+#[derive(Deserialize)]
+struct OpenAIStreamResponse {
+    choices: Vec<OpenAIStreamChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIStreamChoice {
+    delta: OpenAIDelta,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIDelta {
+    content: Option<String>,
+}
+
+#[async_trait]
+impl ChatProvider for OpenAIProvider {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<String> {
+        let openai_messages: Vec<OpenAIMessage> = messages
+            .iter()
+            .map(|m| OpenAIMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect();
+
+        let request = OpenAIRequest {
+            model: self.model.clone(),
+            messages: openai_messages,
+            max_tokens: Some(4096),
+            stream: false,
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("OpenAI API error ({}): {}", status, error_text);
+        }
+
+        let openai_response: OpenAIResponse = response.json().await?;
+
+        let text = openai_response
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default();
+
+        Ok(text)
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[ChatMessage],
+        on_chunk: Box<dyn Fn(StreamChunk) + Send>,
+    ) -> Result<String> {
+        let openai_messages: Vec<OpenAIMessage> = messages
+            .iter()
+            .map(|m| OpenAIMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect();
+
+        let request = OpenAIRequest {
+            model: self.model.clone(),
+            messages: openai_messages,
+            max_tokens: Some(4096),
+            stream: true,
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!("OpenAI API error ({}): {}", status, error_text);
+        }
+
+        let mut full_response = String::new();
+        let mut stream = response.bytes_stream();
+
+        use futures::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            let text = String::from_utf8_lossy(&chunk);
+
+            for line in text.lines() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        on_chunk(StreamChunk {
+                            content: String::new(),
+                            done: true,
+                        });
+                        break;
+                    }
+
+                    if let Ok(parsed) = serde_json::from_str::<OpenAIStreamResponse>(data) {
+                        if let Some(choice) = parsed.choices.first() {
+                            if let Some(content) = &choice.delta.content {
+                                full_response.push_str(content);
+                                on_chunk(StreamChunk {
+                                    content: content.clone(),
+                                    done: choice.finish_reason.is_some(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(full_response)
+    }
+
+    async fn is_available(&self) -> bool {
+        !self.api_key.is_empty()
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[crate::providers::ToolDefinition],
+    ) -> anyhow::Result<crate::providers::ToolCallResult> {
+        use serde_json::{json, Value};
+
+        let openai_messages: Vec<Value> = messages.iter().map(|m| {
+            json!({ "role": m.role, "content": m.content })
+        }).collect();
+
+        let openai_tools: Vec<Value> = tools.iter().map(|t| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.parameters
+                }
+            })
+        }).collect();
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let request = json!({
+            "model": self.model,
+            "messages": openai_messages,
+            "tools": openai_tools,
+            "tool_choice": "auto"
+        });
+
+        let response = self.client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("OpenAI tool call API error ({}): {}", status, body);
+        }
+
+        let body: Value = response.json().await?;
+        let choice = &body["choices"][0]["message"];
+
+        // Check for tool_calls
+        if let Some(tool_calls) = choice["tool_calls"].as_array() {
+            let calls: Vec<crate::providers::ToolCall> = tool_calls
+                .iter()
+                .filter_map(|tc| {
+                    let id = tc["id"].as_str()?.to_string();
+                    let name = tc["function"]["name"].as_str()?.to_string();
+                    let args_str = tc["function"]["arguments"].as_str().unwrap_or("{}");
+                    let args_value: Value = serde_json::from_str(args_str).unwrap_or_default();
+                    let arguments = args_value
+                        .as_object()
+                        .map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| {
+                                    (k.clone(), v.as_str().map(|s| s.to_string())
+                                        .unwrap_or_else(|| v.to_string()))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    Some(crate::providers::ToolCall { id, name, arguments })
+                })
+                .collect();
+
+            if !calls.is_empty() {
+                return Ok(crate::providers::ToolCallResult::ToolCalls(calls));
+            }
+        }
+
+        // Plain text response
+        let text = choice["content"].as_str().unwrap_or("").to_string();
+        Ok(crate::providers::ToolCallResult::Text(text))
+    }
+}


### PR DESCRIPTION
## LLM Provider Backends

Unified interface for 5 LLM backends.

### What's included:
- **ChatProvider trait**: chat(), chat_stream(), chat_with_tools()
- **LocalProvider**: GGUF via llama.cpp, Metal GPU, tool call XML parsing
- **GeminiProvider**: Google Gemini API with functionDeclarations
- **OpenAIProvider**: Any OpenAI-compatible endpoint
- **AnthropicProvider**: Claude API with block content format
- **GroqProvider**: Groq LPU with compound mode (server-side tools)

### Closes
Closes #6, closes #7, closes #8, closes #9, closes #10, closes #11