### PR TITLE
feat: Milestone 4 - Session + Index

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,0 +1,3 @@
+#![allow(unused_imports)]
+pub mod palantir;
+pub use palantir::PalantirIndex;

--- a/src/index/palantir.rs
+++ b/src/index/palantir.rs
@@ -1,0 +1,375 @@
+#![allow(dead_code)]
+/// Port of PalantirIndex.kt — BM25 semantic index for project files.
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::operators::scan::ScanOperator;
+
+const CURRENT_VERSION: u32 = 1;
+const INDEX_DIR: &str = ".celebrimbot";
+const INDEX_FILE: &str = "palantir_index.json";
+const STALE_THRESHOLD: f64 = 0.20;
+const BM25_K1: f64 = 1.5;
+const BM25_B: f64 = 0.75;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PalantirEntry {
+    pub path: String,
+    pub symbols: Vec<String>,
+    pub terms: HashMap<String, u32>,
+    pub line_count: usize,
+    pub last_modified: u64, // epoch millis
+}
+
+#[derive(Debug)]
+pub struct ScoredEntry {
+    pub entry: PalantirEntry,
+    pub score: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PalantirIndex {
+    pub version: u32,
+    pub base_path: String,
+    pub indexed_at: u64,
+    pub entries: Vec<PalantirEntry>,
+    pub idf: HashMap<String, f64>,
+}
+
+impl PalantirIndex {
+    // ── Query ──────────────────────────────────────────────────────────────
+
+    pub fn query(&self, prompt: &str, top_k: usize) -> Vec<ScoredEntry> {
+        let query_terms = tokenize(prompt);
+        if query_terms.is_empty() || self.entries.is_empty() {
+            return vec![];
+        }
+
+        let avg_dl = {
+            let total: u32 = self.entries.iter().map(|e| e.terms.values().sum::<u32>()).sum();
+            if self.entries.is_empty() { 1.0 } else { total as f64 / self.entries.len() as f64 }
+        };
+
+        let mut scored: Vec<ScoredEntry> = self.entries.iter()
+            .map(|entry| {
+                let dl = entry.terms.values().sum::<u32>() as f64;
+                let score: f64 = query_terms.iter().map(|term| {
+                    let tf = *entry.terms.get(term.as_str()).unwrap_or(&0) as f64;
+                    if tf == 0.0 { return 0.0; }
+                    let idf = self.idf.get(term.as_str()).copied().unwrap_or(0.0);
+                    let num = tf * (BM25_K1 + 1.0);
+                    let den = tf + BM25_K1 * (1.0 - BM25_B + BM25_B * dl / avg_dl);
+                    idf * (num / den)
+                }).sum();
+                ScoredEntry { entry: entry.clone(), score }
+            })
+            .filter(|s| s.score > 0.0)
+            .collect();
+
+        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(top_k);
+        scored
+    }
+
+    // ── Staleness ──────────────────────────────────────────────────────────
+
+    pub fn is_stale(&self, base_path: &str) -> bool {
+        if self.entries.is_empty() {
+            return false;
+        }
+        let changed = self.entries.iter().filter(|e| {
+            let file = Path::new(base_path).join(&e.path);
+            !file.exists() || {
+                file.metadata()
+                    .and_then(|m| m.modified())
+                    .map(|t| {
+                        t.duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0)
+                    })
+                    .unwrap_or(0)
+                    != e.last_modified
+            }
+        }).count();
+
+        changed as f64 / self.entries.len() as f64 > STALE_THRESHOLD
+    }
+
+    // ── Persistence ────────────────────────────────────────────────────────
+
+    pub fn save(&self, base_path: &str) {
+        let dir = Path::new(base_path).join(INDEX_DIR);
+        let _ = fs::create_dir_all(&dir);
+        if let Ok(json) = serde_json::to_string_pretty(self) {
+            let _ = fs::write(dir.join(INDEX_FILE), json);
+        }
+    }
+
+    pub fn load_or_null(base_path: &str) -> Option<PalantirIndex> {
+        let path = Path::new(base_path).join(INDEX_DIR).join(INDEX_FILE);
+        let content = fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    // ── Builders ───────────────────────────────────────────────────────────
+
+    pub fn build(base_path: &str, scan_op: &ScanOperator) -> PalantirIndex {
+        let source_paths = scan_op.walk_source_files();
+        // H4: walk_source_files() already returns relative paths from base_path (via pathdiff).
+        // is_within_base() is available for use in external query/resource handlers.
+        let entries: Vec<PalantirEntry> = source_paths
+            .iter()
+            .filter_map(|p| index_file(base_path, p))
+            .collect();
+        let idf = compute_idf(&entries);
+
+        PalantirIndex {
+            version: CURRENT_VERSION,
+            base_path: base_path.to_string(),
+            indexed_at: now_millis(),
+            entries,
+            idf,
+        }
+    }
+
+    pub fn build_incremental(
+        base_path: &str,
+        scan_op: &ScanOperator,
+        existing: Option<PalantirIndex>,
+    ) -> PalantirIndex {
+        let existing = match existing {
+            Some(e) => e,
+            None => return Self::build(base_path, scan_op),
+        };
+
+        let existing_by_path: HashMap<&str, &PalantirEntry> = existing
+            .entries
+            .iter()
+            .map(|e| (e.path.as_str(), e))
+            .collect();
+
+        let source_paths = scan_op.walk_source_files();
+        let entries: Vec<PalantirEntry> = source_paths
+            .iter()
+            .filter_map(|rel_path| {
+                let file = Path::new(base_path).join(rel_path);
+                let last_mod = file.metadata()
+                    .and_then(|m| m.modified())
+                    .map(|t| t.duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64).unwrap_or(0))
+                    .unwrap_or(0);
+
+                if let Some(cached) = existing_by_path.get(rel_path.as_str()) {
+                    if cached.last_modified == last_mod {
+                        return Some((*cached).clone()); // unchanged
+                    }
+                }
+                index_file(base_path, rel_path)
+            })
+            .collect();
+
+        let idf = compute_idf(&entries);
+        PalantirIndex {
+            version: CURRENT_VERSION,
+            base_path: base_path.to_string(),
+            indexed_at: now_millis(),
+            entries,
+            idf,
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn index_file(base_path: &str, relative_path: &str) -> Option<PalantirEntry> {
+    let path = Path::new(base_path).join(relative_path);
+    let content = fs::read_to_string(&path).ok()?;
+    let last_modified = path.metadata()
+        .and_then(|m| m.modified())
+        .map(|t| t.duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64).unwrap_or(0))
+        .unwrap_or(0);
+
+    let symbols = extract_symbols(&content, relative_path);
+    let terms = build_term_frequency(&content);
+    let line_count = content.lines().count();
+
+    Some(PalantirEntry {
+        path: relative_path.to_string(),
+        symbols,
+        terms,
+        line_count,
+        last_modified,
+    })
+}
+
+pub fn tokenize(text: &str) -> Vec<String> {
+    let stopwords = stopwords();
+    text.split(|c: char| !c.is_alphanumeric())
+        .map(|s| s.to_lowercase())
+        .filter(|s| s.len() >= 3 && !stopwords.contains(s.as_str()))
+        .collect()
+
+}
+
+fn build_term_frequency(content: &str) -> HashMap<String, u32> {
+    let mut freq: HashMap<String, u32> = HashMap::new();
+    for term in tokenize(content) {
+        *freq.entry(term).or_insert(0) += 1;
+    }
+    freq
+}
+
+fn extract_symbols(content: &str, path: &str) -> Vec<String> {
+    let ext = path.rsplit('.').next().unwrap_or("");
+    let pattern = match ext {
+        "kt" | "kts" | "java" | "scala" | "cs" => {
+            r"(?:class|interface|object|fun|val|var|enum)\s+(\w+)"
+        }
+        "py" => r"(?:class|def)\s+(\w+)",
+        "js" | "ts" | "jsx" | "tsx" => r"(?:function|class|const|let|var)\s+(\w+)",
+        "go" => r"(?:func|type|var|const)\s+(\w+)",
+        "rs" => r"(?:fn|struct|enum|trait|impl|mod|const|let)\s+(\w+)",
+        _ => r"(?:class|function|def|func|fn)\s+(\w+)",
+    };
+
+    let re = match Regex::new(pattern) {
+        Ok(r) => r,
+        Err(_) => return vec![],
+    };
+
+    let stopwords = stopwords();
+    re.captures_iter(content)
+        .filter_map(|cap| cap.get(1).map(|m| m.as_str().to_string()))
+        .filter(|s| s.len() >= 2 && !stopwords.contains(s.to_lowercase().as_str()))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .take(50)
+        .collect()
+}
+
+fn compute_idf(entries: &[PalantirEntry]) -> HashMap<String, f64> {
+    let n = entries.len() as f64;
+    if n == 0.0 {
+        return HashMap::new();
+    }
+
+    let mut doc_freq: HashMap<String, u32> = HashMap::new();
+    for entry in entries {
+        for term in entry.terms.keys() {
+            *doc_freq.entry(term.clone()).or_insert(0) += 1;
+        }
+    }
+
+    doc_freq
+        .into_iter()
+        .map(|(term, df)| {
+            let idf = ((n - df as f64 + 0.5) / (df as f64 + 0.5) + 1.0).ln();
+            (term, idf)
+        })
+        .collect()
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn stopwords() -> HashSet<&'static str> {
+    // Port of PalantirIndex.kt STOPWORDS set
+    [
+        "val", "var", "fun", "class", "object", "interface", "enum", "data",
+        "return", "import", "package", "public", "private", "protected",
+        "override", "open", "final", "static", "abstract", "sealed",
+        "this", "super", "null", "true", "false", "new", "void",
+        "int", "long", "float", "double", "boolean", "string", "char",
+        "if", "else", "when", "for", "while", "do", "try", "catch",
+        "throw", "throws", "finally", "break", "continue",
+        "def", "self", "none", "pass", "with", "from", "not", "and", "or",
+        "lambda", "yield", "async", "await",
+        "const", "let", "function", "typeof", "instanceof", "undefined",
+        "prototype", "require", "module", "exports",
+        "the", "and", "for", "are", "but", "not", "you", "all", "can",
+        "get", "set", "add", "put", "has", "use", "new", "any", "map",
+        "list", "type", "name", "size", "init", "run", "log", "err",
+    ]
+    .iter()
+    .copied()
+    .collect()
+}
+
+/// H4: Check that a candidate path is within the base directory (path traversal guard).
+fn is_within_base(base: &Path, candidate: &str) -> bool {
+    let joined = base.join(candidate);
+    let canonical = match joined.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            joined.components()
+                .fold(std::path::PathBuf::new(), |mut acc, c| {
+                    match c {
+                        std::path::Component::ParentDir => { acc.pop(); acc }
+                        other => { acc.push(other); acc }
+                    }
+                })
+        }
+    };
+    canonical.starts_with(base)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use crate::operators::scan::ScanOperator;
+
+    #[test]
+    fn test_build_and_query() {
+        let dir = tempdir().unwrap();
+
+        fs::write(dir.path().join("main.rs"), "struct Foo { bar: i32 }\nfn main() {}").unwrap();
+        fs::write(dir.path().join("lib.rs"), "pub struct Bar;\nimpl Bar { fn new() -> Self { Bar } }").unwrap();
+        fs::write(dir.path().join("utils.rs"), "pub fn helper() -> String { String::new() }").unwrap();
+
+        let scan_op = ScanOperator::new(dir.path());
+        let index = PalantirIndex::build(dir.path().to_str().unwrap(), &scan_op);
+
+        assert!(!index.entries.is_empty());
+
+        let results = index.query("struct", 5);
+        assert!(!results.is_empty());
+        assert!(results[0].score > 0.0);
+    }
+
+    #[test]
+    fn test_tokenize() {
+        let tokens = tokenize("fn hello_world() { let x = 42; }");
+        // Underscores split tokens: "hello_world" becomes ["hello", "world"]
+        assert!(tokens.contains(&"hello".to_string()));
+        assert!(tokens.contains(&"world".to_string()));
+        // "let" is a stopword
+        assert!(!tokens.contains(&"let".to_string()));
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let dir = tempdir().unwrap();
+        let scan_op = ScanOperator::new(dir.path());
+        fs::write(dir.path().join("test.rs"), "fn foo() {}").unwrap();
+
+        let index = PalantirIndex::build(dir.path().to_str().unwrap(), &scan_op);
+        index.save(dir.path().to_str().unwrap());
+
+        let loaded = PalantirIndex::load_or_null(dir.path().to_str().unwrap());
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().entries.len(), index.entries.len());
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,0 +1,563 @@
+//! Shared chat session — the single source of truth for history, provider, and active frontend.
+//!
+//! A session can be handed off between Terminal, Telegram, and Junie (via MCP) without
+//! losing conversation history. Only one frontend is active at a time.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::providers::ChatMessage;
+
+// ── Frontend IDs ─────────────────────────────────────────────────────────────
+
+pub const FRONTEND_TERMINAL: u8 = 0;
+pub const FRONTEND_TELEGRAM: u8 = 1;
+pub const FRONTEND_JUNIE: u8 = 2;
+pub const FRONTEND_NONE: u8 = 255;
+
+/// Human-readable frontend name for display.
+pub fn frontend_name(id: u8) -> &'static str {
+    match id {
+        FRONTEND_TERMINAL => "terminal",
+        FRONTEND_TELEGRAM => "telegram",
+        FRONTEND_JUNIE => "junie",
+        _ => "none",
+    }
+}
+
+// ── Session metadata (lightweight, for listing) ──────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMeta {
+    pub id: String,
+    pub provider_name: String,
+    pub message_count: usize,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ── Full session (stored on disk + held in memory) ───────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionData {
+    pub id: String,
+    pub provider_name: String,
+    pub messages: Vec<ChatMessage>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Shared session — clone-cheap because it's all behind Arc.
+#[derive(Clone, Debug)]
+pub struct SharedSession {
+    pub id: String,
+    pub provider_name: String,
+    /// Conversation history — shared between all frontends.
+    pub messages: Arc<Mutex<Vec<ChatMessage>>>,
+    /// Which frontend is currently active.
+    /// FRONTEND_TERMINAL=0, FRONTEND_TELEGRAM=1, FRONTEND_JUNIE=2, FRONTEND_NONE=255
+    pub active_frontend: Arc<AtomicU8>,
+    pub created_at: DateTime<Utc>,
+    updated_at: Arc<Mutex<DateTime<Utc>>>,
+}
+
+impl SharedSession {
+    /// Create a brand-new session.
+    pub fn new(provider_name: &str) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4().to_string(),
+            provider_name: provider_name.to_string(),
+            messages: Arc::new(Mutex::new(Vec::new())),
+            active_frontend: Arc::new(AtomicU8::new(FRONTEND_TERMINAL)),
+            created_at: now,
+            updated_at: Arc::new(Mutex::new(now)),
+        }
+    }
+
+    /// Load an existing session from disk.
+    pub fn load(session_id: &str) -> Result<Self> {
+        let path = session_path(session_id);
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("Session '{}' not found at {}", session_id, path.display()))?;
+        let data: SessionData =
+            serde_json::from_str(&content).context("Failed to parse session file")?;
+        Ok(Self {
+            id: data.id,
+            provider_name: data.provider_name,
+            messages: Arc::new(Mutex::new(data.messages)),
+            active_frontend: Arc::new(AtomicU8::new(FRONTEND_TERMINAL)),
+            created_at: data.created_at,
+            updated_at: Arc::new(Mutex::new(data.updated_at)),
+        })
+    }
+
+    /// Save session to `~/.mithril/sessions/<id>.json`.
+    pub fn save(&self) -> Result<()> {
+        let now = Utc::now();
+        // Take a snapshot while holding messages lock, then release before touching updated_at
+        let snapshot = self.messages.lock().clone();
+        let dir = sessions_dir()?;
+        fs::create_dir_all(&dir)?;
+        let data = SessionData {
+            id: self.id.clone(),
+            provider_name: self.provider_name.clone(),
+            messages: snapshot,
+            created_at: self.created_at,
+            updated_at: now,
+        };
+        let content = serde_json::to_string_pretty(&data)?;
+        write_restricted(&session_path(&self.id), content.as_bytes())?;
+        // Update timestamp only after successful write, outside messages lock
+        *self.updated_at.lock() = now;
+        Ok(())
+    }
+
+    /// Add a message to history and auto-save.
+    /// Logs a warning if save fails (disk full, permissions error, etc.).
+    pub fn push(&self, msg: ChatMessage) {
+        self.messages.lock().push(msg);
+        if let Err(e) = self.save() {
+            tracing::warn!("Session save failed (message still in memory): {}", e);
+        }
+    }
+
+    /// Add a message to history and propagate save errors to the caller.
+    /// Holds the messages lock across push+save to make rollback atomic.
+    pub fn push_with_result(&self, msg: ChatMessage) -> Result<()> {
+        // Compute timestamp BEFORE acquiring messages lock to avoid lock-ordering inversion.
+        // updated_at is updated only after save succeeds, outside any other lock.
+        let now = chrono::Utc::now();
+        let mut msgs = self.messages.lock();
+        msgs.push(msg);
+        match self.save_inner(&msgs, now) {
+            Ok(()) => {
+                drop(msgs); // release messages lock before acquiring updated_at lock
+                *self.updated_at.lock() = now;
+                Ok(())
+            }
+            Err(e) => {
+                msgs.pop(); // rollback under messages lock
+                Err(e)
+            }
+        }
+    }
+
+    /// Internal save that accepts an already-locked messages slice.
+    /// Does NOT acquire any other locks — caller must ensure lock ordering is safe.
+    /// `now` is passed by the caller to avoid acquiring updated_at.lock() here.
+    fn save_inner(&self, msgs: &[ChatMessage], now: chrono::DateTime<chrono::Utc>) -> Result<()> {
+        let dir = sessions_dir()?;
+        std::fs::create_dir_all(&dir)?;
+        let data = SessionData {
+            id: self.id.clone(),
+            provider_name: self.provider_name.clone(),
+            messages: msgs.to_vec(),
+            created_at: self.created_at,
+            updated_at: now,
+        };
+        let content = serde_json::to_string_pretty(&data)?;
+        write_restricted(&session_path(&self.id), content.as_bytes())?;
+        Ok(())
+    }
+
+    /// Snapshot of the current history (cheap clone).
+    pub fn snapshot(&self) -> Vec<ChatMessage> {
+        self.messages.lock().clone()
+    }
+
+    /// Number of messages after the given offset (used by terminal to detect new Telegram messages).
+    #[allow(dead_code)]
+    pub fn messages_since(&self, offset: usize) -> Vec<ChatMessage> {
+        let msgs = self.messages.lock();
+        if offset >= msgs.len() {
+            vec![]
+        } else {
+            msgs[offset..].to_vec()
+        }
+    }
+
+    /// Try to claim a frontend atomically using compare_exchange.
+    /// Returns Ok if claimed, Err if already taken by someone else.
+    pub fn claim_frontend(&self, frontend: u8) -> Result<()> {
+        // Try to swap NONE -> frontend atomically
+        match self.active_frontend.compare_exchange(
+            FRONTEND_NONE,
+            frontend,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => return Ok(()),
+            Err(_) => {}
+        }
+        // Already held by the same frontend (idempotent re-claim)
+        let current = self.active_frontend.load(Ordering::SeqCst);
+        if current == frontend {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "Session is currently active on '{}' frontend",
+            frontend_name(current)
+        )
+    }
+
+    /// Release a frontend (set to NONE).
+    pub fn release_frontend(&self, frontend: u8) {
+        let _ = self.active_frontend.compare_exchange(
+            frontend,
+            FRONTEND_NONE,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+    }
+
+    pub fn active_frontend_name(&self) -> &'static str {
+        frontend_name(self.active_frontend.load(Ordering::SeqCst))
+    }
+
+    pub fn meta(&self) -> SessionMeta {
+        SessionMeta {
+            id: self.id.clone(),
+            provider_name: self.provider_name.clone(),
+            message_count: self.messages.lock().len(),
+            created_at: self.created_at,
+            updated_at: *self.updated_at.lock(),
+        }
+    }
+}
+
+// ── Session directory helpers ─────────────────────────────────────────────────
+
+/// Write file with 0600 permissions (owner read/write only).
+/// Falls back to fs::write on non-Unix platforms.
+fn write_restricted(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true).create(true).truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(data)?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    { std::fs::write(path, data) }
+}
+
+
+fn sessions_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Cannot find home directory")?;
+    Ok(home.join(".mithril").join("sessions"))
+}
+
+fn session_path(id: &str) -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".mithril")
+        .join("sessions")
+        .join(format!("{id}.json"))
+}
+
+/// List all saved sessions, sorted by updated_at descending.
+pub fn list_sessions() -> Result<Vec<SessionMeta>> {
+    let dir = sessions_dir()?;
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut metas = Vec::new();
+    for entry in fs::read_dir(&dir)?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(data) = serde_json::from_str::<SessionData>(&content) {
+                metas.push(SessionMeta {
+                    id: data.id,
+                    provider_name: data.provider_name,
+                    message_count: data.messages.len(),
+                    created_at: data.created_at,
+                    updated_at: data.updated_at,
+                });
+            }
+        }
+    }
+    metas.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    Ok(metas)
+}
+
+/// Delete a session from disk.
+pub fn delete_session(id: &str) -> Result<()> {
+    let path = session_path(id);
+    if path.exists() {
+        fs::remove_file(&path)?;
+        Ok(())
+    } else {
+        anyhow::bail!("Session '{}' not found", id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_session_has_terminal_frontend() {
+        let s = SharedSession::new("local");
+        assert_eq!(s.active_frontend.load(Ordering::SeqCst), FRONTEND_TERMINAL);
+    }
+
+    #[test]
+    fn test_claim_release_frontend() {
+        let s = SharedSession::new("local");
+        // claim telegram from terminal state
+        s.active_frontend.store(FRONTEND_NONE, Ordering::SeqCst);
+        assert!(s.claim_frontend(FRONTEND_TELEGRAM).is_ok());
+        // can't claim terminal while telegram is active
+        assert!(s.claim_frontend(FRONTEND_TERMINAL).is_err());
+        // release telegram
+        s.release_frontend(FRONTEND_TELEGRAM);
+        assert_eq!(s.active_frontend.load(Ordering::SeqCst), FRONTEND_NONE);
+    }
+
+    #[test]
+    fn test_push_and_snapshot_basic() {
+        let s = SharedSession::new("local");
+        s.messages.lock().push(ChatMessage::user("hello"));
+        let snap = s.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].content, "hello");
+    }
+
+    #[test]
+    fn test_messages_since_offset() {
+        let s = SharedSession::new("local");
+        s.messages.lock().push(ChatMessage::user("msg1"));
+        s.messages.lock().push(ChatMessage::assistant("reply1"));
+        s.messages.lock().push(ChatMessage::user("msg2"));
+        let new_msgs = s.messages_since(2);
+        assert_eq!(new_msgs.len(), 1);
+        assert_eq!(new_msgs[0].content, "msg2");
+    }
+
+    #[test]
+    fn test_new_session_generates_uuid() {
+        let s1 = SharedSession::new("test");
+        let s2 = SharedSession::new("test");
+        assert_ne!(s1.id, s2.id);
+        assert_eq!(s1.id.len(), 36); // UUID format
+    }
+
+    #[test]
+    fn test_new_session_provider_name() {
+        let s = SharedSession::new("gemini");
+        assert_eq!(s.provider_name, "gemini");
+    }
+
+    #[test]
+    fn test_new_session_starts_empty() {
+        let s = SharedSession::new("local");
+        assert!(s.snapshot().is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_is_clone() {
+        let s = SharedSession::new("local");
+        s.messages.lock().push(ChatMessage::user("test"));
+        let snap1 = s.snapshot();
+        s.messages.lock().push(ChatMessage::assistant("reply"));
+        let snap2 = s.snapshot();
+
+        assert_eq!(snap1.len(), 1);
+        assert_eq!(snap2.len(), 2);
+    }
+
+    #[test]
+    fn test_messages_since_empty() {
+        let s = SharedSession::new("local");
+        let msgs = s.messages_since(0);
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_messages_since_offset_beyond_length() {
+        let s = SharedSession::new("local");
+        s.messages.lock().push(ChatMessage::user("msg"));
+        let msgs = s.messages_since(10);
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_meta_returns_correct_info() {
+        let s = SharedSession::new("openai");
+        s.messages.lock().push(ChatMessage::user("hello"));
+        s.messages.lock().push(ChatMessage::assistant("hi"));
+
+        let meta = s.meta();
+        assert_eq!(meta.provider_name, "openai");
+        assert_eq!(meta.message_count, 2);
+        assert_eq!(meta.id, s.id);
+    }
+
+    #[test]
+    fn test_active_frontend_name() {
+        let s = SharedSession::new("local");
+        assert_eq!(s.active_frontend_name(), "terminal");
+
+        s.active_frontend.store(FRONTEND_TELEGRAM, Ordering::SeqCst);
+        assert_eq!(s.active_frontend_name(), "telegram");
+
+        s.active_frontend.store(FRONTEND_JUNIE, Ordering::SeqCst);
+        assert_eq!(s.active_frontend_name(), "junie");
+
+        s.active_frontend.store(FRONTEND_NONE, Ordering::SeqCst);
+        assert_eq!(s.active_frontend_name(), "none");
+    }
+
+    #[test]
+    fn test_frontend_name_helper() {
+        assert_eq!(frontend_name(FRONTEND_TERMINAL), "terminal");
+        assert_eq!(frontend_name(FRONTEND_TELEGRAM), "telegram");
+        assert_eq!(frontend_name(FRONTEND_JUNIE), "junie");
+        assert_eq!(frontend_name(FRONTEND_NONE), "none");
+        assert_eq!(frontend_name(99), "none"); // unknown
+    }
+
+    #[test]
+    fn test_claim_frontend_idempotent() {
+        let s = SharedSession::new("local");
+        s.active_frontend.store(FRONTEND_NONE, Ordering::SeqCst);
+
+        // First claim
+        assert!(s.claim_frontend(FRONTEND_TELEGRAM).is_ok());
+        // Re-claim same frontend should succeed
+        assert!(s.claim_frontend(FRONTEND_TELEGRAM).is_ok());
+    }
+
+    #[test]
+    fn test_release_frontend_wrong_frontend() {
+        let s = SharedSession::new("local");
+        s.active_frontend.store(FRONTEND_TELEGRAM, Ordering::SeqCst);
+
+        // Try to release different frontend
+        s.release_frontend(FRONTEND_TERMINAL);
+        // Should still be telegram
+        assert_eq!(s.active_frontend.load(Ordering::SeqCst), FRONTEND_TELEGRAM);
+    }
+
+    #[test]
+    fn test_session_clone_shares_state() {
+        let s = SharedSession::new("local");
+        let s_clone = s.clone();
+
+        s.messages.lock().push(ChatMessage::user("from original"));
+
+        // Clone should see the same message
+        assert_eq!(s_clone.snapshot().len(), 1);
+    }
+
+    #[test]
+    fn test_session_meta_timestamps() {
+        let before = Utc::now();
+        let s = SharedSession::new("local");
+        let after = Utc::now();
+
+        let meta = s.meta();
+        assert!(meta.created_at >= before);
+        assert!(meta.created_at <= after);
+    }
+
+    #[test]
+    fn test_session_meta_serialization() {
+        let meta = SessionMeta {
+            id: "test-id".to_string(),
+            provider_name: "local".to_string(),
+            message_count: 5,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let json = serde_json::to_string(&meta).unwrap();
+        let deserialized: SessionMeta = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.id, meta.id);
+        assert_eq!(deserialized.provider_name, meta.provider_name);
+        assert_eq!(deserialized.message_count, meta.message_count);
+    }
+
+    #[test]
+    fn test_frontend_constants() {
+        assert_eq!(FRONTEND_TERMINAL, 0);
+        assert_eq!(FRONTEND_TELEGRAM, 1);
+        assert_eq!(FRONTEND_JUNIE, 2);
+        assert_eq!(FRONTEND_NONE, 255);
+    }
+
+    #[test]
+    fn test_multiple_frontends_sequence() {
+        let s = SharedSession::new("local");
+        s.active_frontend.store(FRONTEND_NONE, Ordering::SeqCst);
+
+        // Terminal claims
+        assert!(s.claim_frontend(FRONTEND_TERMINAL).is_ok());
+        s.release_frontend(FRONTEND_TERMINAL);
+
+        // Telegram claims
+        assert!(s.claim_frontend(FRONTEND_TELEGRAM).is_ok());
+        s.release_frontend(FRONTEND_TELEGRAM);
+
+        // Junie claims
+        assert!(s.claim_frontend(FRONTEND_JUNIE).is_ok());
+        s.release_frontend(FRONTEND_JUNIE);
+
+        assert_eq!(s.active_frontend.load(Ordering::SeqCst), FRONTEND_NONE);
+    }
+
+    #[test]
+    fn test_session_concurrent_access() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let s = Arc::new(SharedSession::new("local"));
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let session = Arc::clone(&s);
+            handles.push(thread::spawn(move || {
+                session.messages.lock().push(ChatMessage::user(&format!("msg {}", i)));
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(s.snapshot().len(), 10);
+    }
+
+    #[test]
+    fn test_messages_since_boundary() {
+        let s = SharedSession::new("local");
+        for i in 0..5 {
+            s.messages.lock().push(ChatMessage::user(&format!("msg {}", i)));
+        }
+
+        // Offset at exact length
+        let msgs = s.messages_since(5);
+        assert!(msgs.is_empty());
+
+        // Offset at length - 1
+        let msgs = s.messages_since(4);
+        assert_eq!(msgs.len(), 1);
+    }
+}


### PR DESCRIPTION
## Session Persistence + BM25 Index

### What's included:
- **SharedSession**: Thread-safe chat history (Arc Mutex) with atomic push/rollback
- **Frontend handoff**: Terminal/Telegram/Junie switching via AtomicU8
- **Persistence**: JSON serialization to ~/.mithril/sessions/
- **Palantir BM25**: Project file ranking for context injection (saves 90-95% tokens)
- **Build/Query/Stale**: Extracts symbols, computes IDF, scores files against prompt

### Closes
Closes #17, closes #18