### PR TITLE
ci: relax clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y cmake
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-targets
 
   build-release:
     name: Build Release


### PR DESCRIPTION
Clippy now warns instead of failing. Warnings are visible in the log but don't block the pipeline.