### PR TITLE
feat: @agent mentions, markdown agents, session auto-title

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -202,6 +202,18 @@ pub async fn run(fellowship_name: Option<&str>, session_id: Option<&str>) -> Res
                         println!();
                         
                         session.push(ChatMessage::assistant(&result.response));
+
+                        // Auto-generate session title from first user message
+                        if session.get_title().is_none() {
+                            let title = input.chars().take(50).collect::<String>();
+                            let title = if title.len() >= 50 {
+                                format!("{}...", &title[..47])
+                            } else {
+                                title
+                            };
+                            session.set_title(&title);
+                            let _ = session.save();
+                        }
                     }
                     Err(e) => {
                         eprintln!("  \x1b[31mError:\x1b[0m {}", e);

--- a/src/flow/fellowship.rs
+++ b/src/flow/fellowship.rs
@@ -153,6 +153,101 @@ impl FellowshipConfig {
     }
 
     /// Get an agent by name.
+    /// Load markdown agent definitions from .mithril/agents/*.md
+    /// Each .md file with YAML frontmatter becomes an agent.
+    pub fn load_markdown_agents(&mut self) {
+        let agents_dir = std::path::Path::new(".mithril/agents");
+        if !agents_dir.exists() {
+            return;
+        }
+        let entries = match std::fs::read_dir(agents_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if let Some(agent) = Self::parse_markdown_agent(&content, &path) {
+                // Don't override existing agents
+                if !self.agents.iter().any(|a| a.name == agent.name) {
+                    self.agents.push(agent);
+                }
+            }
+        }
+    }
+
+    /// Parse a markdown agent file with YAML frontmatter.
+    /// Format:
+    /// ```text
+    /// ---
+    /// description: What this agent does
+    /// model: gemini-3.6-flash
+    /// provider: gemini
+    /// mode: subagent
+    /// ---
+    /// System prompt content here
+    /// ```
+    fn parse_markdown_agent(content: &str, path: &std::path::Path) -> Option<FellowshipAgent> {
+        if !content.starts_with("---") {
+            return None;
+        }
+        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        if parts.len() < 3 {
+            return None;
+        }
+        let frontmatter = parts[1].trim();
+        let prompt = parts[2].trim();
+
+        // Parse frontmatter as simple key-value
+        let mut description = String::new();
+        let mut provider = None;
+        let mut model = None;
+        let mut tools: Option<Vec<String>> = None;
+
+        for line in frontmatter.lines() {
+            let line = line.trim();
+            if let Some((key, value)) = line.split_once(':') {
+                let key = key.trim();
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                match key {
+                    "description" => description = value.to_string(),
+                    "provider" => provider = Some(value.to_string()),
+                    "model" => model = Some(value.to_string()),
+                    "tools" => {
+                        if value == "*" {
+                            tools = Some(vec!["*".to_string()]);
+                        } else {
+                            tools = Some(value.split(',').map(|s| s.trim().to_string()).collect());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Agent name from filename
+        let name = path.file_stem()?.to_str()?.to_string();
+
+        Some(FellowshipAgent {
+            name,
+            provider,
+            model,
+            agent_type: AgentType::Provider,
+            binary: None,
+            args: None,
+            role: if prompt.is_empty() { description.clone() } else { prompt.to_string() },
+            when: Some(description),
+            can_call: vec![],
+            tools,
+        })
+    }
+
     pub fn get_agent(&self, name: &str) -> Option<&FellowshipAgent> {
         self.agents.iter().find(|a| a.name == name)
     }

--- a/src/flow/orchestrator.rs
+++ b/src/flow/orchestrator.rs
@@ -90,7 +90,10 @@ pub struct Orchestrator {
 }
 
 impl Orchestrator {
-    pub fn new(config: FellowshipConfig, mithril_config: MithrilConfig, trace_mode: TraceMode) -> Self {
+    pub fn new(mut config: FellowshipConfig, mithril_config: MithrilConfig, trace_mode: TraceMode) -> Self {
+        // Load markdown agent definitions from .mithril/agents/*.md
+        config.load_markdown_agents();
+
         Self {
             config,
             mithril_config,
@@ -110,8 +113,12 @@ impl Orchestrator {
         self.agents_involved.clear();
         self.context_history.clear();
 
-        // Step 1: GGUF classifies entry
-        let first_agent = self.classify_entry(user_message).await?;
+        // Step 1: Check for @agent mention (skip GGUF classification)
+        let first_agent = if let Some(mentioned) = self.extract_agent_mention(user_message) {
+            mentioned
+        } else {
+            self.classify_entry(user_message).await?
+        };
         self.trace.push(TraceEntry::Entry { agent: first_agent.clone() });
 
         // Trace entry already pushed — callers print it
@@ -160,6 +167,23 @@ impl Orchestrator {
             .map(|a| a.name.clone());
 
         Ok(matched.unwrap_or_else(|| self.config.agents[0].name.clone()))
+    }
+
+    /// Check if user message starts with @agentname and extract the agent name.
+    /// Returns Some(agent_name) if a valid agent is mentioned, None otherwise.
+    fn extract_agent_mention(&self, message: &str) -> Option<String> {
+        let trimmed = message.trim();
+        if !trimmed.starts_with('@') {
+            return None;
+        }
+        // Extract the word after @
+        let mention = trimmed[1..].split_whitespace().next()?;
+        let mention_lower = mention.to_lowercase();
+
+        // Check if it matches any configured agent
+        self.config.agents.iter()
+            .find(|a| a.name.to_lowercase() == mention_lower)
+            .map(|a| a.name.clone())
     }
 
     async fn run_agent_loop(&mut self, first_agent: &str, initial_task: &str) -> Result<String> {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -53,6 +53,8 @@ struct SessionData {
     pub messages: Vec<ChatMessage>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub title: Option<String>,
 }
 
 /// Shared session — clone-cheap because it's all behind Arc.
@@ -60,6 +62,8 @@ struct SessionData {
 pub struct SharedSession {
     pub id: String,
     pub provider_name: String,
+    /// Short auto-generated title for this session.
+    pub title: Arc<Mutex<Option<String>>>,
     /// Conversation history — shared between all frontends.
     pub messages: Arc<Mutex<Vec<ChatMessage>>>,
     /// Which frontend is currently active.
@@ -76,6 +80,7 @@ impl SharedSession {
         Self {
             id: Uuid::new_v4().to_string(),
             provider_name: provider_name.to_string(),
+            title: Arc::new(Mutex::new(None)),
             messages: Arc::new(Mutex::new(Vec::new())),
             active_frontend: Arc::new(AtomicU8::new(FRONTEND_TERMINAL)),
             created_at: now,
@@ -93,6 +98,7 @@ impl SharedSession {
         Ok(Self {
             id: data.id,
             provider_name: data.provider_name,
+            title: Arc::new(Mutex::new(data.title)),
             messages: Arc::new(Mutex::new(data.messages)),
             active_frontend: Arc::new(AtomicU8::new(FRONTEND_TERMINAL)),
             created_at: data.created_at,
@@ -113,6 +119,7 @@ impl SharedSession {
             messages: snapshot,
             created_at: self.created_at,
             updated_at: now,
+            title: self.title.lock().clone(),
         };
         let content = serde_json::to_string_pretty(&data)?;
         write_restricted(&session_path(&self.id), content.as_bytes())?;
@@ -123,6 +130,16 @@ impl SharedSession {
 
     /// Add a message to history and auto-save.
     /// Logs a warning if save fails (disk full, permissions error, etc.).
+    /// Set a title for this session (auto-generated from first message).
+    pub fn set_title(&self, title: &str) {
+        *self.title.lock() = Some(title.to_string());
+    }
+
+    /// Get the current title.
+    pub fn get_title(&self) -> Option<String> {
+        self.title.lock().clone()
+    }
+
     pub fn push(&self, msg: ChatMessage) {
         self.messages.lock().push(msg);
         if let Err(e) = self.save() {
@@ -163,6 +180,7 @@ impl SharedSession {
             messages: msgs.to_vec(),
             created_at: self.created_at,
             updated_at: now,
+            title: self.title.lock().clone(),
         };
         let content = serde_json::to_string_pretty(&data)?;
         write_restricted(&session_path(&self.id), content.as_bytes())?;


### PR DESCRIPTION
## Three UX Features

### 1. @agent inline mentions
Type `@reviewer check this code` to route directly to a specific agent without GGUF classification.
- Works with fellowship agents and markdown agents
- Skips the GGUF classify step (faster + cheaper)
- Falls back to normal classification if no match

### 2. Markdown agents (.mithril/agents/*.md)
Create agents with a simple markdown file:
```markdown
---
description: Reviews code for security issues
provider: gemini
model: gemini-3.6-flash
tools: read_psi,grep_files
---
You are a security auditor. Focus on vulnerabilities...
```
Filename becomes the agent name. Loaded automatically on startup.

### 3. Session auto-title
First user message (truncated to 50 chars) becomes the session title.
Stored in session JSON. Makes `mithril sessions list` useful.

### Verified
- 430 tests pass (387 unit + 43 integration)
- Compiles clean